### PR TITLE
Calling returned functions

### DIFF
--- a/DLOAD.md
+++ b/DLOAD.md
@@ -14,9 +14,10 @@ dload("librequests.so", "httpget");
 
 #include <hermes/AST.h>
 #include <hermes/dynamic_list.h>
+#include <hermes/hermes_runtime.h>
 
 
-AST_T* getpi(AST_T* self, dynamic_list_T* args)
+AST_T* getpi(runtime_T* runtime, AST_T* self, dynamic_list_T* args)
 {
     AST_T* float_ast = init_ast(AST_FLOAT);
     float_ast->float_value = 3.14;

--- a/examples/call_function.he
+++ b/examples/call_function.he
@@ -1,0 +1,8 @@
+print("start");
+
+void do_something()
+{
+    print("hello");
+}
+
+do_something();

--- a/examples/call_returned_func.he
+++ b/examples/call_returned_func.he
@@ -1,7 +1,3 @@
-/**
-* This does not work, but should work
-*/
-
 void getfunc()
 {
     return void @(string name)

--- a/examples/call_returned_func.he
+++ b/examples/call_returned_func.he
@@ -10,4 +10,4 @@ void getfunc()
     }
 }
 
-getfunc()("john");
+getfunc()("doe");

--- a/src/AST.c
+++ b/src/AST.c
@@ -611,9 +611,11 @@ char* ast_function_definition_to_string(AST_T* ast)
 
 char* ast_function_call_to_string(AST_T* ast)
 {
+    char* expr_str = ast_to_string(ast->function_call_expr);
+
     const char* template = "%s (%d)";
-    char* str = calloc(strlen(template) + /*strlen(ast->function_call_name)*/ + 128, sizeof(char));
-    sprintf(str, template, "?", (int)ast->function_call_arguments->size);
+    char* str = calloc(strlen(template) + strlen(expr_str) + 128, sizeof(char));
+    sprintf(str, template, expr_str, (int)ast->function_call_arguments->size);
 
     return str;
 }

--- a/src/AST.c
+++ b/src/AST.c
@@ -11,7 +11,7 @@ AST_T* init_ast(int type)
     AST_T* AST = calloc(1, sizeof(struct AST_STRUCT));
     AST->type = type;
     AST->line_n = -1;
-    AST->function_call_name = (void*) 0;
+    AST->function_call_expr = (void*) 0;
     AST->int_value = 0;
     AST->boolean_value = 0;
     AST->is_object_child = 0;
@@ -97,8 +97,8 @@ void ast_free(AST_T* ast)
     if (ast->type == AST_FUNCTION_DEFINITION || ast->type == AST_VARIABLE_DEFINITION)
         return;
 
-    if (ast->function_call_name)
-        free(ast->function_call_name);
+    if (ast->function_call_expr)
+        ast_free(ast->function_call_expr);
 
     if (ast->string_value)
         free(ast->string_value); 
@@ -462,8 +462,7 @@ AST_T* ast_copy_variable_modifier(AST_T* ast)
 AST_T* ast_copy_function_call(AST_T* ast)
 {
     AST_T* a = init_ast(ast->type);
-    a->function_call_name = calloc(strlen(ast->function_call_name) + 1, sizeof(char));
-    strcpy(a->function_call_name, ast->function_call_name);
+    a->function_call_expr = ast_copy(ast->function_call_expr);
 
     for (int i = 0; i < ast->function_call_arguments->size; i++)
     {
@@ -613,8 +612,8 @@ char* ast_function_definition_to_string(AST_T* ast)
 char* ast_function_call_to_string(AST_T* ast)
 {
     const char* template = "%s (%d)";
-    char* str = calloc(strlen(template) + strlen(ast->function_call_name) + 128, sizeof(char));
-    sprintf(str, template, ast->function_call_name, (int)ast->function_call_arguments->size);
+    char* str = calloc(strlen(template) + /*strlen(ast->function_call_name)*/ + 128, sizeof(char));
+    sprintf(str, template, "?", (int)ast->function_call_arguments->size);
 
     return str;
 }

--- a/src/dl.c
+++ b/src/dl.c
@@ -1,11 +1,12 @@
 #include "include/dl.h"
 #include <dlfcn.h>
+#include "include/hermes_runtime.h"
 
 
 AST_T* get_dl_function(char* filename, char* funcname)
 {
     void *handle;
-    struct AST_STRUCT* (*fptr)(struct AST_STRUCT* self, dynamic_list_T* args);
+    struct AST_STRUCT* (*fptr)(runtime_T* runtime, struct AST_STRUCT* self, dynamic_list_T* args);
     char *error;
 
     handle = dlopen(filename, RTLD_LAZY);

--- a/src/hermes_parser.c
+++ b/src/hermes_parser.c
@@ -151,12 +151,10 @@ AST_T* hermes_parser_parse_statement(hermes_parser_T* hermes_parser, hermes_scop
 
             hermes_parser_eat(hermes_parser, TOKEN_ID);
 
-            AST_T* a = (void*) 0;
+            AST_T* a = hermes_parser_parse_variable(hermes_parser, scope);
 
-            if (hermes_parser->current_token->type == TOKEN_LPAREN)
-                a = hermes_parser_parse_function_call(hermes_parser, scope);
-            else
-                a = hermes_parser_parse_variable(hermes_parser, scope);
+            while (hermes_parser->current_token->type == TOKEN_LPAREN)
+                a = hermes_parser_parse_function_call(hermes_parser, scope, a);
 
             while (hermes_parser->current_token->type == TOKEN_DOT)
             {
@@ -483,7 +481,7 @@ AST_T* hermes_parser_parse_factor(hermes_parser_T* hermes_parser, hermes_scope_T
 
         switch (hermes_parser->current_token->type)
         {
-            case TOKEN_LPAREN: a = hermes_parser_parse_function_call(hermes_parser, scope); break;
+            //case TOKEN_LPAREN: a = hermes_parser_parse_function_call(hermes_parser, scope); break;
             default: a = hermes_parser_parse_variable(hermes_parser, scope); break;
         }
 
@@ -543,6 +541,9 @@ AST_T* hermes_parser_parse_term(hermes_parser_T* hermes_parser, hermes_scope_T* 
 
     AST_T* node = hermes_parser_parse_factor(hermes_parser, scope);
     AST_T* ast_binop = (void*) 0;
+
+    if (hermes_parser->current_token->type == TOKEN_LPAREN)
+        node = hermes_parser_parse_function_call(hermes_parser, scope, node);
 
     while (
         hermes_parser->current_token->type == TOKEN_DIV ||        
@@ -775,11 +776,10 @@ AST_T* hermes_parser_parse_while(hermes_parser_T* hermes_parser, hermes_scope_T*
 
 // functions
 
-AST_T* hermes_parser_parse_function_call(hermes_parser_T* hermes_parser, hermes_scope_T* scope)
+AST_T* hermes_parser_parse_function_call(hermes_parser_T* hermes_parser, hermes_scope_T* scope, AST_T* expr)
 {
     AST_T* ast_function_call = init_ast_with_line(AST_FUNCTION_CALL, hermes_parser->hermes_lexer->line_n);
-    ast_function_call->function_call_name = calloc(strlen(hermes_parser->prev_token->value) + 1, sizeof(char));
-    strcpy(ast_function_call->function_call_name, hermes_parser->prev_token->value);
+    ast_function_call->function_call_expr = expr;
     hermes_parser_eat(hermes_parser, TOKEN_LPAREN);
     ast_function_call->scope = (struct hermes_scope_T*) scope;
 

--- a/src/hermes_parser.c
+++ b/src/hermes_parser.c
@@ -506,6 +506,9 @@ AST_T* hermes_parser_parse_factor(hermes_parser_T* hermes_parser, hermes_scope_T
             a = ast_list_access;
         }
 
+        while(hermes_parser->current_token->type == TOKEN_LPAREN)
+            a = hermes_parser_parse_function_call(hermes_parser, scope, a);
+
         if (a)
             return a;
     }

--- a/src/hermes_runtime.c
+++ b/src/hermes_runtime.c
@@ -103,7 +103,7 @@ static AST_T* _runtime_function_call(runtime_T* runtime, AST_T* fcall, AST_T* fd
 
     if(fcall->function_call_arguments->size != fdef->function_definition_arguments->size){
         printf("Error: [Line %d] %s Expected %ld arguments but found %ld arguments\n",
-                fcall->line_n, "?",//fcall->function_call_name,
+                fcall->line_n, fdef->function_name,
                 fdef->function_definition_arguments->size,
                 fcall->function_call_arguments->size);
 

--- a/src/hermes_runtime.c
+++ b/src/hermes_runtime.c
@@ -713,49 +713,10 @@ AST_T* runtime_function_lookup(runtime_T* runtime, hermes_scope_T* scope, AST_T*
 {
     AST_T* function_definition = (void*)0;
 
-    //printf("%d\n", node->type);
     AST_T* visited_expr = runtime_visit(runtime, node->function_call_expr);
 
     if (visited_expr->type == AST_FUNCTION_DEFINITION)
         function_definition = visited_expr;
-
-
-    /**
-     * First, check if there is a variable definition assigned with a 
-     * function definition.
-     */
-    /*for (int i = 0; i < scope->variable_definitions->size; i++)
-    {
-        AST_T* vardef = (AST_T*) scope->variable_definitions->items[i];
-
-        if (strcmp(node->function_call_name, vardef->variable_name) == 0)
-        {
-            if (vardef->variable_value->type == AST_FUNCTION_DEFINITION)
-            {
-                function_definition = vardef->variable_value;
-                break;
-            }
-        }
-    }*/
-
-    /**
-     * If we did not find a variable definition assigned with a function
-     * defintion, then keep looking in function definitions instead.
-     */
-    /*if (function_definition == (void*) 0)
-    {
-        for (int i = 0; i < scope->function_definitions->size; i++)
-        {
-            function_definition = (AST_T*) scope->function_definitions->items[i];
-            
-            if (strcmp(function_definition->function_name, node->function_call_name) == 0)
-            {
-                break; 
-            }
-
-            function_definition = (void*)0;
-        }
-    }*/
 
     if (function_definition == (void*)0)
         return (void*)0;
@@ -1064,7 +1025,12 @@ AST_T* runtime_visit_attribute_access(runtime_T* runtime, AST_T* node)
         }
     }
 
-    // call a function attached to some sort of value.
+    /**
+     * Call a function attached to some sort of value.
+     *
+     * TODO: dont do this. It might be possible to fetch the function
+     * definition in antoher way. Maybe in visit_variable?
+     */
     if (node->binop_right->type == AST_FUNCTION_CALL)
     {
         if (node->binop_right->function_call_expr->type == AST_VARIABLE)

--- a/src/include/AST.h
+++ b/src/include/AST.h
@@ -4,6 +4,9 @@
 #include "dynamic_list.h"
 #include "token.h"
 
+
+struct RUNTIME_STRUCT;
+
 typedef struct AST_STRUCT
 {
     enum {
@@ -104,7 +107,7 @@ typedef struct AST_STRUCT
     
     struct hermes_scope_T* scope;
 
-    struct AST_STRUCT* (*fptr)(struct AST_STRUCT* self, dynamic_list_T* args);
+    struct AST_STRUCT* (*fptr)(struct RUNTIME_STRUCT* runtime, struct AST_STRUCT* self, dynamic_list_T* args);
 } AST_T;
 
 AST_T* init_ast(int type);

--- a/src/include/AST.h
+++ b/src/include/AST.h
@@ -42,7 +42,7 @@ typedef struct AST_STRUCT
         AST_ASSERT
     } type;
     
-    char* function_call_name;
+    struct AST_STRUCT* function_call_expr;
 
     int line_n;
     int int_value;

--- a/src/include/hermes_builtins.h
+++ b/src/include/hermes_builtins.h
@@ -1,35 +1,44 @@
 #ifndef HERMES_BUILTINS_H
 #define HERMES_BUILTINS_H
 #include "AST.h"
+#include "hermes_runtime.h"
 
 
-AST_T* hermes_builtin_function_print(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_print(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_aprint(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_stdoutbuffer(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_include(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_aprint(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_wad(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_include(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_lad(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_wad(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_fopen(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_lad(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_fclose(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_fopen(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_fputs(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_fclose(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_input(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_fputs(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_char_to_bin(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_input(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_char_to_oct(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_char_to_bin(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_char_to_dec(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_char_to_oct(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_char_to_hex(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_char_to_dec(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* hermes_builtin_function_time(AST_T* self, dynamic_list_T* args);
+AST_T* hermes_builtin_function_char_to_hex(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
+
+AST_T* hermes_builtin_function_time(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
+
+AST_T* hermes_builtin_function_dload(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
+
+AST_T* hermes_builtin_function_free(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
+
+AST_T* hermes_builtin_function_visit(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
 AST_T* INITIALIZED_NOOP;
 #endif

--- a/src/include/hermes_parser.h
+++ b/src/include/hermes_parser.h
@@ -91,7 +91,7 @@ AST_T* hermes_parser_parse_while(hermes_parser_T* hermes_parser, hermes_scope_T*
 
 // functions
 
-AST_T* hermes_parser_parse_function_call(hermes_parser_T* hermes_parser, hermes_scope_T* scope);
+AST_T* hermes_parser_parse_function_call(hermes_parser_T* hermes_parser, hermes_scope_T* scope, AST_T* expr);
 
 AST_T* hermes_parser_parse_function_definition(hermes_parser_T* hermes_parser, hermes_scope_T* scope);
 


### PR DESCRIPTION
* Changed how function calls are being parsed
* Removed `function_call_name` from AST and replaced it with `function_call_expr`
* Put builtin functions in `hermes_builtins.c`