### PR TITLE
Changed INITIALIZED_NOOP to be static

### DIFF
--- a/src/include/hermes_builtins.h
+++ b/src/include/hermes_builtins.h
@@ -45,5 +45,5 @@ AST_T* hermes_builtin_function_strrev(runtime_T* runtime, AST_T* self, dynamic_l
 
 AST_T* hermes_builtin_function_ssh(runtime_T* runtime, AST_T* self, dynamic_list_T* args);
 
-AST_T* INITIALIZED_NOOP;
+static AST_T* INITIALIZED_NOOP;
 #endif


### PR DESCRIPTION
I changed INITIALIZED_NOOP to be static, since the linker would throw a multiple definitions error